### PR TITLE
Allow fade to be called early, in _ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Fade.fade_in()
 ```
 And it will return to normal.
 
-Note that, while fade can be called anywhere at any time, it will fail if you call it right at the project launch (e.g. in `_ready()` method of your main scene). If you want to fade that early for whatever reason, wait a single frame.
-
 ## How to scene transition
 
 Fading out and in is cool and all, but you probably want to use it for something other than itself. The most common usage is scene transiton. You can use this piece of code:

--- a/addons/UniversalFade/Fade.gd
+++ b/addons/UniversalFade/Fade.gd
@@ -62,7 +62,7 @@ static func _create_fader(color: Color, pattern: String, reverse: bool, smooth: 
 	var fader = load("res://addons/UniversalFade/Fade.tscn").instantiate()
 	fader._prepare_fade(color, texture, reverse, smooth, _get_scene_tree_root().get_meta(&"__crossfade__", false))
 	_get_scene_tree_root().set_meta(&"__current_fade__", fader)
-	_get_scene_tree_root().add_child(fader)
+	_get_scene_tree_root().add_child.call_deferred(fader)
 	return fader
 
 static func _get_scene_tree_root() -> Viewport:


### PR DESCRIPTION
Looks like this was the only call preventing fades to be called early, so can just defer it.